### PR TITLE
[Task] Sequence

### DIFF
--- a/src/calc/range/range.ts
+++ b/src/calc/range/range.ts
@@ -11,6 +11,10 @@ export const clamp = (v: number, range: Range): number => {
   return Math.min(Math.max(lowerBound, v), upperBound);
 };
 
+export const delta = (range: Range): number => {
+  return Math.abs(range[1] - range[0]);
+};
+
 export const progress = (v: number, range: Range): number => {
   const clamped = clamp(v, range);
   const delta = clamped - range[0];

--- a/src/normal/index.ts
+++ b/src/normal/index.ts
@@ -1,7 +1,7 @@
+export * from './types';
+export * from './sequence';
+export * from './tween';
 /**
- * @TODO timeline
  * @TODO group
  * @TODO stagger
  */
-export * from './types';
-export * from './tween';

--- a/src/normal/index.ts
+++ b/src/normal/index.ts
@@ -1,2 +1,7 @@
+/**
+ * @TODO timeline
+ * @TODO group
+ * @TODO stagger
+ */
 export * from './types';
 export * from './tween';

--- a/src/normal/sequence/index.ts
+++ b/src/normal/sequence/index.ts
@@ -1,0 +1,1 @@
+export * from './sequence';

--- a/src/normal/sequence/sequence.test.ts
+++ b/src/normal/sequence/sequence.test.ts
@@ -1,0 +1,145 @@
+import { tween } from '../tween';
+import { current, normalize, range, sequence } from './sequence';
+
+describe('current(t, offset)', () => {
+  it('Returns t if offset not specified', () => {
+    expect(current(500)).toEqual(500);
+  });
+  it('Returns offset if offset is a number', () => {
+    expect(current(500, 1000)).toEqual(1000);
+  });
+  it('Returns the output of offset if offset is a function', () => {
+    expect(current(500, (t: number) => t + 50)).toEqual(550);
+  });
+});
+
+describe('range(config)', () => {
+  it('Provides a range from standard config', () => {
+    expect(
+      range({
+        first: {
+          normal: tween({ duration: 200, from: 0, to: 1 }),
+        },
+        second: {
+          normal: tween({ duration: 800, from: 0, to: 1 }),
+        },
+      })
+    ).toEqual([0, 1000]);
+  });
+
+  it('Provides a range from negative config', () => {
+    expect(
+      range({
+        first: {
+          normal: tween({ duration: 200, from: 0, to: 1 }),
+        },
+        second: {
+          offset: -500,
+          normal: tween({ duration: 1000, from: 0, to: 1 }),
+        },
+      })
+    ).toEqual([-500, 500]);
+
+    expect(
+      range({
+        first: {
+          normal: tween({ duration: 100, from: 0, to: 1 }),
+        },
+        second: {
+          offset: (t) => t - 500,
+          normal: tween({ duration: 500, from: 0, to: 1 }),
+        },
+      })
+    ).toEqual([-400, 100]);
+  });
+});
+
+describe('normalize(config)', () => {
+  it('Returns an object of the same shape of the config', () => {
+    expect(
+      Object.keys(
+        normalize({
+          first: {
+            normal: tween({ duration: 100, from: 0, to: 1 }),
+          },
+          second: {
+            normal: tween({ duration: 100, from: 0, to: 1 }),
+          },
+          third: {
+            normal: tween({ duration: 100, from: 0, to: 1 }),
+          },
+        })
+      )
+    ).toEqual(['first', 'second', 'third']);
+  });
+
+  it('Returns an object with normalized ranges', () => {
+    expect(
+      normalize({
+        first: {
+          normal: tween({ duration: 100, from: 0, to: 1 }),
+        },
+        second: {
+          normal: tween({ duration: 100, from: 0, to: 1 }),
+        },
+        third: {
+          normal: tween({ duration: 100, from: 0, to: 1 }),
+        },
+        fourth: {
+          normal: tween({ duration: 100, from: 0, to: 1 }),
+        },
+      })
+    ).toEqual({
+      first: [0, 0.25],
+      second: [0.25, 0.5],
+      third: [0.5, 0.75],
+      fourth: [0.75, 1],
+    });
+  });
+});
+
+describe('sequence(config)', () => {
+  it('Interpolates a standard range', () => {
+    const { progress } = sequence({
+      first: {
+        normal: tween({ duration: 100, from: 0, to: 1 }),
+      },
+      second: {
+        normal: tween({ duration: 100, from: 0, to: 1 }),
+      },
+    });
+
+    expect(progress(0)).toEqual({ first: 0, second: 0 });
+    expect(progress(0.25)).toEqual({ first: 0.5, second: 0 });
+    expect(progress(0.5)).toEqual({ first: 1, second: 0 });
+    expect(progress(0.75)).toEqual({ first: 1, second: 0.5 });
+    expect(progress(1)).toEqual({ first: 1, second: 1 });
+  });
+
+  it('Returns the duration with no offset entries', () => {
+    const { duration } = sequence({
+      first: {
+        normal: tween({ duration: 100, from: 0, to: 1 }),
+      },
+      second: {
+        normal: tween({ duration: 100, from: 0, to: 1 }),
+      },
+    });
+
+    expect(duration()).toEqual(200);
+  });
+
+  it('Returns the duration with offset entries', () => {
+    const { duration } = sequence({
+      first: {
+        normal: tween({ duration: 100, from: 0, to: 1 }),
+      },
+      second: {
+        offset: (t) => t - 1000,
+        normal: tween({ duration: 100, from: 0, to: 1 }),
+      },
+    });
+
+    expect(duration()).toEqual(1000);
+  });
+});

--- a/src/normal/sequence/sequence.ts
+++ b/src/normal/sequence/sequence.ts
@@ -1,0 +1,83 @@
+import { NORMAL, Range, transform } from 'calc';
+import { emitter } from 'emitter';
+import { Normal } from '../types';
+
+type Offset = number | ((t: number) => number);
+type Entry<T = any> = {
+  normal: Normal<T>;
+  offset?: Offset;
+};
+type Config<T extends Entry<number | object>> = {
+  [k: string]: T;
+};
+type Value<T extends Config<Entry<any>>> = {
+  [k in keyof T]: ReturnType<T[keyof T]['normal']['progress']>;
+};
+
+const current = (t: number, offset?: Offset): number => {
+  return !offset ? t : typeof offset === 'number' ? t + offset : offset(t);
+};
+
+export const range = (config: Config<Entry<any>>): Range => {
+  return Object.values(config).reduce<Range>(
+    (r, entry) => {
+      const t = current(r[1], entry.offset);
+      const start = Math.min(r[0], t);
+      const end = Math.max(r[1], t + entry.normal.duration());
+      return [start, end];
+    },
+    [0, 0]
+  );
+};
+
+type Normalized<T extends Config<Entry>> = {
+  [k in keyof T]: Range;
+};
+const normalize = <T extends Config<Entry>>(config: T): Normalized<T> => {
+  const sequenceRange = range(config);
+  return Object.entries(config).reduce<[Normalized<T>, number]>(
+    ([normalized, t], [key, entry]) => {
+      const now = current(t, entry.offset);
+      const entryRange: Range = [now, now + entry.normal.duration()];
+      normalized[key as keyof T] = [
+        entryRange[0] / sequenceRange[0],
+        entryRange[1] / sequenceRange[1],
+      ];
+
+      return [normalized, Math.max(t, current(t, entry.offset))];
+    },
+    [{} as Normalized<T>, 0]
+  )[0];
+};
+
+type Interpolator<T extends Config<Entry>> = (p: number) => Value<T>;
+const interpolator = <T extends Config<Entry>>(config: T): Interpolator<T> => {
+  const normalized = normalize(config);
+
+  return (p) =>
+    Object.entries(config).reduce<Value<T>>((value, [key, entry]) => {
+      const entryProgress = transform(p, normalized[key], NORMAL);
+      value[key as keyof T] = entry.normal.progress(entryProgress);
+      return value;
+    }, {} as Value<T>);
+};
+
+export const sequence = <T extends Config<Entry<any>>>(
+  config: T
+): Normal<Value<T>> => {
+  const subscription = emitter<Value<T>>();
+  const sequenceRange = range(config);
+  const sequenceInterpolator = interpolator(config);
+
+  return {
+    duration: () => {
+      return sequenceRange[1] - sequenceRange[0];
+    },
+    progress: (p: number) => {
+      const interpolated = sequenceInterpolator(p);
+      subscription.emit(interpolated);
+      return interpolated;
+    },
+    subscribe: subscription.subscribe,
+  };
+};


### PR DESCRIPTION
- adds `sequence(config)`

**usage**
```
const { progress, subscribe } = sequence({
  first: {
    normal: tween({ duration: 400, from: 0, to: 1 })
  },
  second: {
    offset: t => t - 50,
    normal: tween({ 
      duration: 800, 
      from: { 
        property1: 0,
        property2: 50
      }
      to: {
        property1: 30,
        property2: 900
      }
     })
  }
});

/**
  progress(|0 - 1|);

  outputs & emits:
  {
    first: number,
    second: {
        property1: number,
        property2: number
    }
  }
 */

/**
  subscribe(v => {
    typeof v === {
      first: number,
      second: {
          property1: number,
          property2: number
      }
    }
  });
 */
```