### PR TITLE
Task/stagger

### DIFF
--- a/src/emitter/emitter.test.ts
+++ b/src/emitter/emitter.test.ts
@@ -2,13 +2,13 @@ import { emitter } from './emitter';
 
 describe('emitter()', () => {
   it('Can Emit to multiple subscribers', () => {
-    const subscription = emitter<number>();
+    const stream = emitter<number>();
     const subscribers = Array.from({ length: 10 }, () => jest.fn());
     subscribers.forEach((subscriber) => {
-      subscription.subscribe(subscriber);
+      stream.subscribe(subscriber);
     });
 
-    subscription.emit(1);
+    stream.next(1);
     subscribers.forEach((subscriber) => {
       expect(subscriber).toBeCalledTimes(1);
     });
@@ -18,15 +18,15 @@ describe('emitter()', () => {
     const numSubscribers = 50;
     const unnsubscribedIndex = numSubscribers / 2;
 
-    const subscription = emitter<number>();
+    const stream = emitter<number>();
     const subscribers = Array.from({ length: numSubscribers }, () => jest.fn());
 
     const unsubscribe = subscribers.map((subscriber) => {
-      return subscription.subscribe(subscriber);
+      return stream.subscribe(subscriber);
     });
     unsubscribe[unnsubscribedIndex]();
 
-    subscription.emit(1);
+    stream.next(1);
     subscribers.forEach((subscriber, i) => {
       expect(subscriber).toBeCalledTimes(i === unnsubscribedIndex ? 0 : 1);
     });

--- a/src/emitter/emitter.ts
+++ b/src/emitter/emitter.ts
@@ -1,9 +1,9 @@
 export type Subscriber<T> = (v: T) => void;
 export type Unsubscribe = () => void;
 export type Subscribe<T> = (subscriber: Subscriber<T>) => Unsubscribe;
-export type Emit<T> = (v: T) => void;
+export type Next<T> = (v: T) => void;
 export type Emitter<T> = {
-  emit: Emit<T>;
+  next: Next<T>;
   subscribe: Subscribe<T>;
 };
 
@@ -18,14 +18,14 @@ export const emitter = <T>(): Emitter<T> => {
     };
   };
 
-  const emit: Emit<T> = (v) => {
+  const next: Next<T> = (v) => {
     subscriptions.forEach((subscriber) => {
       subscriber(v);
     });
   };
 
   return {
-    emit,
+    next,
     subscribe,
   };
 };

--- a/src/normal/stagger/stagger.test.ts
+++ b/src/normal/stagger/stagger.test.ts
@@ -1,0 +1,49 @@
+import { tween } from '../tween';
+import { stagger } from './stagger';
+
+describe('stagger', () => {
+  it('Calculates duration for number staggers', () => {
+    expect(
+      stagger({
+        length: 6,
+        stagger: 100,
+        normal: tween({
+          duration: 500,
+          from: 0,
+          to: 1,
+        }),
+      }).duration()
+    ).toEqual(1000);
+  });
+
+  it('Calculates duration for functional staggers', () => {
+    expect(
+      stagger({
+        length: 8,
+        stagger: (i) => (i % 2) * 25,
+        normal: tween({
+          duration: 500,
+          from: 0,
+          to: 1,
+        }),
+      }).duration()
+    ).toEqual(500 + 25);
+  });
+
+  it('Interpolates correctly', () => {
+    const { progress } = stagger({
+      length: 4,
+      stagger: 100,
+      normal: tween({
+        duration: 100,
+        from: 0,
+        to: 1,
+      }),
+    });
+    expect(progress(0)).toEqual([0, 0, 0, 0]);
+    expect(progress(0.25)).toEqual([1, 0, 0, 0]);
+    expect(progress(0.5)).toEqual([1, 1, 0, 0]);
+    expect(progress(0.75)).toEqual([1, 1, 1, 0]);
+    expect(progress(1)).toEqual([1, 1, 1, 1]);
+  });
+});

--- a/src/normal/stagger/stagger.ts
+++ b/src/normal/stagger/stagger.ts
@@ -1,0 +1,19 @@
+import { Normal } from '../types';
+import { emitter } from './emitter';
+
+type Config = {};
+
+export const stagger = <T extends Normal<any>>(config: Config): Normal<T[]> => {
+  const subscription = emitter<T[]>();
+
+  return {
+    duration: () => {
+      return 300;
+    },
+    progress: (p: number) => {
+      console.log(p);
+      return [];
+    },
+    subscribe: subscription.subscribe,
+  };
+};

--- a/src/normal/stagger/stagger.ts
+++ b/src/normal/stagger/stagger.ts
@@ -1,4 +1,4 @@
-import { clamp, NORMAL, Range } from 'calc';
+import { clamp, delta, NORMAL, Range, transform } from 'calc';
 import { emitter } from 'emitter';
 import { Normal } from '../types';
 
@@ -8,28 +8,49 @@ type Config<T> = {
   normal: Normal<T>;
 };
 
-const interpolator = <T>(config: Config<T>) => {
-  const stagger = Array.from({ length: config.length }, (_, i) =>
+export const range = <T>(config: Config<T>): Range => {
+  const duration = config.normal.duration();
+  const staggers = Array.from({ length: config.length }, (_, i) =>
     typeof config.stagger === 'number' ? config.stagger : config.stagger(i)
   );
 
+  return staggers.reduce<Range>(
+    (r, stagger) => {
+      return [Math.min(r[0], stagger), Math.max(r[1], stagger + duration)];
+    },
+    [staggers[0], staggers[0] + duration]
+  );
+};
+
+export const interpolator = <T>(config: Config<T>) => {
+  const staggers = Array.from({ length: config.length }, (_, i) =>
+    typeof config.stagger === 'number' ? config.stagger : config.stagger(i)
+  );
+  const duration = config.normal.duration();
+  const configRange = range(config);
+  const normalized = staggers.map<Range>((stagger) => [
+    stagger / delta(configRange),
+    (stagger + duration) / delta(configRange),
+  ]);
+
   return (p: number): T[] => {
     const clamped = clamp(p, NORMAL);
-    console.log(clamped, stagger);
-    return [];
+    return normalized.map<T>((stagger) => {
+      return config.normal.progress(transform(clamped, stagger, NORMAL));
+    });
   };
 };
 
 export const stagger = <T>(config: Config<T>): Normal<T[]> => {
   const stream = emitter<T[]>();
   const configured = {
-    range: [0, 1] as Range,
+    range: range(config),
     interpolator: interpolator(config),
   };
 
   return {
     duration: () => {
-      return 300;
+      return delta(configured.range);
     },
     progress: (p: number) => {
       const interpolated = configured.interpolator(p);

--- a/src/normal/tween/tween.ts
+++ b/src/normal/tween/tween.ts
@@ -3,13 +3,13 @@ import { Ease, ease } from 'ease';
 import { emitter } from 'emitter';
 import { Normal } from '../types';
 
-type Value = {
+export type Value = {
   [k: string]: number;
 };
-type ShapeOf<T> = {
+export type ShapeOf<T> = {
   [k in keyof T]: number;
 };
-type Config<T> = {
+export type Config<T> = {
   duration?: number;
   ease?: Ease;
   from: T;
@@ -17,9 +17,7 @@ type Config<T> = {
 };
 type ConditionalConfig<T> = T extends Value ? Config<T> : Config<number>;
 
-const isNumberConfig = <T extends Value | number>(
-  config: Config<T | number>
-): config is Config<number> => {
+const isNumberConfig = (config: any): config is Config<number> => {
   return typeof config.from === 'number';
 };
 
@@ -47,15 +45,15 @@ export function tween<T extends Value>(config: Config<T>): Normal<ShapeOf<T>>;
 export function tween<T>(
   config: ConditionalConfig<T>
 ): Normal<ShapeOf<T> | number> {
-  const subscription = emitter<ShapeOf<T> | number>();
+  const stream = emitter<ShapeOf<T> | number>();
 
   return {
     duration: () => config.duration || 300,
     progress: (v) => {
       const interpolated = interpolator(config)(v);
-      subscription.emit(interpolated);
+      stream.next(interpolated);
       return interpolated;
     },
-    subscribe: subscription.subscribe,
+    subscribe: stream.subscribe,
   };
 }


### PR DESCRIPTION
- Adds `stagger(config)` & tests
```
    const { progress } = stagger({
      length: 4,
      stagger: 100,
      normal: tween({
        duration: 100,
        from: 0,
        to: 1,
      }),
    });

    progress(0) // [0, 0, 0, 0]
    progress(0.25) // [1, 0, 0, 0]
    progress(0.5) // [1, 1, 0, 0])
    progress(0.75) // [1, 1, 1, 0]
    progress(1) // [1, 1, 1, 1]
```