### PR TITLE
[TASK] group

### DIFF
--- a/src/normal/group/group.test.ts
+++ b/src/normal/group/group.test.ts
@@ -1,0 +1,89 @@
+import { group } from './group';
+import { tween } from '../tween';
+
+describe('group(config)', () => {
+  it('Calculates duration as duration of the longest entry', () => {
+    const { duration } = group({
+      one: tween({
+        duration: 500,
+        from: 0,
+        to: 1,
+      }),
+      two: tween({
+        duration: 1000,
+        from: 0,
+        to: 1,
+      }),
+      three: tween({
+        duration: 200,
+        from: 0,
+        to: 1,
+      }),
+    });
+    expect(duration()).toEqual(1000);
+  });
+
+  it('Interpolates to object of the same shape correctly', () => {
+    const { progress } = group({
+      one: tween({
+        duration: 250,
+        from: 0,
+        to: 1,
+      }),
+      two: tween({
+        duration: 500,
+        from: 0,
+        to: 1,
+      }),
+      three: tween({
+        duration: 1000,
+        from: {
+          property: 0,
+        },
+        to: {
+          property: 1,
+        },
+      }),
+    });
+
+    expect(progress(0)).toEqual({
+      one: 0,
+      two: 0,
+      three: {
+        property: 0,
+      },
+    });
+
+    expect(progress(0.25)).toEqual({
+      one: 1,
+      two: 0.5,
+      three: {
+        property: 0.25,
+      },
+    });
+
+    expect(progress(0.5)).toEqual({
+      one: 1,
+      two: 1,
+      three: {
+        property: 0.5,
+      },
+    });
+
+    expect(progress(0.75)).toEqual({
+      one: 1,
+      two: 1,
+      three: {
+        property: 0.75,
+      },
+    });
+
+    expect(progress(1)).toEqual({
+      one: 1,
+      two: 1,
+      three: {
+        property: 1,
+      },
+    });
+  });
+});

--- a/src/normal/group/group.ts
+++ b/src/normal/group/group.ts
@@ -1,0 +1,71 @@
+import { emitter } from 'emitter';
+import { delta, clamp, transform, NORMAL, Range } from 'calc';
+import { Normal } from '../types';
+
+type Entry<T = any> = Normal<T>;
+export type Config<T extends Entry<number | object>> = {
+  [k: string]: T;
+};
+type Value<T extends Config<Entry>> = {
+  [k in keyof T]: ReturnType<T[keyof T]['progress']>;
+};
+
+const range = <T extends Config<Entry>>(config: T): Range => {
+  return Object.values(config).reduce<Range>(
+    (r, entry) => [r[0], Math.max(r[1], entry.duration())],
+    [0, 0]
+  );
+};
+
+type Normalized<T extends Config<Entry>> = {
+  [k in keyof T]: Range;
+};
+const normalize = <T extends Config<Entry>>(config: T): Normalized<T> => {
+  const duration = delta(range(config));
+  return Object.entries(config).reduce<Normalized<T>>(
+    (normalized, [key, entry]) => {
+      normalized[key as keyof T] = [0, entry.duration() / duration];
+      return normalized;
+    },
+    {} as Normalized<T>
+  );
+};
+
+type Interpolator<T extends Config<Entry>> = (p: number) => Value<T>;
+const interpolator = <T extends Config<Entry>>(config: T): Interpolator<T> => {
+  const normalized = normalize(config);
+  return (p) => {
+    const clamped = clamp(p, NORMAL);
+    return Object.entries(config).reduce<Value<T>>((value, [key, entry]) => {
+      value[key as keyof T] = entry.progress(
+        transform(clamped, normalized[key], NORMAL)
+      );
+      return value;
+    }, {} as Value<T>);
+  };
+};
+
+export const group = <T extends Config<Entry>>(config: T): Normal<Value<T>> => {
+  const stream = emitter<Value<T>>();
+  const configured = {
+    range: Object.values(config).reduce<Range>(
+      (r, entry) => {
+        return [0, Math.max(r[1], entry.duration())];
+      },
+      [0, 0]
+    ),
+    interpolator: interpolator(config),
+  };
+
+  return {
+    duration: () => {
+      return delta(configured.range);
+    },
+    progress: (p: number) => {
+      const interpolated = configured.interpolator(p);
+      stream.next(interpolated);
+      return interpolated;
+    },
+    subscribe: stream.subscribe,
+  };
+};

--- a/src/normal/group/index.ts
+++ b/src/normal/group/index.ts
@@ -1,0 +1,1 @@
+export * from './group';

--- a/src/normal/index.ts
+++ b/src/normal/index.ts
@@ -1,7 +1,5 @@
 export * from './types';
-export * from './sequence';
-export * from './tween';
-/**
- * @TODO group
- * @TODO stagger
- */
+export { group, Config as GroupConfig } from './group';
+export { sequence, Config as SequenceConfig } from './sequence';
+export { stagger, Config as StaggerConfig } from './stagger';
+export { tween, Config as TweenConfig } from './tween';

--- a/src/normal/sequence/sequence.ts
+++ b/src/normal/sequence/sequence.ts
@@ -7,10 +7,10 @@ type Entry<T = any> = {
   normal: Normal<T>;
   offset?: Offset;
 };
-type Config<T extends Entry<number | object>> = {
+export type Config<T extends Entry<number | object>> = {
   [k: string]: T;
 };
-type Value<T extends Config<Entry<any>>> = {
+type Value<T extends Config<Entry>> = {
   [k in keyof T]: ReturnType<T[keyof T]['normal']['progress']>;
 };
 
@@ -18,7 +18,7 @@ export const current = (t: number, offset?: Offset): number => {
   return !offset ? t : typeof offset === 'number' ? offset : offset(t);
 };
 
-export const range = (config: Config<Entry<any>>): Range => {
+export const range = (config: Config<Entry>): Range => {
   return Object.values(config).reduce<Range>(
     (r, entry) => {
       const t = current(r[1], entry.offset);
@@ -55,17 +55,17 @@ export const normalize = <T extends Config<Entry>>(
 type Interpolator<T extends Config<Entry>> = (p: number) => Value<T>;
 const interpolator = <T extends Config<Entry>>(config: T): Interpolator<T> => {
   const normalized = normalize(config);
-
-  return (p) =>
-    Object.entries(config).reduce<Value<T>>((value, [key, entry]) => {
-      const clamped = clamp(p, NORMAL);
+  return (p) => {
+    const clamped = clamp(p, NORMAL);
+    return Object.entries(config).reduce<Value<T>>((value, [key, entry]) => {
       const entryProgress = transform(clamped, normalized[key], NORMAL);
       value[key as keyof T] = entry.normal.progress(entryProgress);
       return value;
     }, {} as Value<T>);
+  };
 };
 
-export const sequence = <T extends Config<Entry<any>>>(
+export const sequence = <T extends Config<Entry>>(
   config: T
 ): Normal<Value<T>> => {
   const stream = emitter<Value<T>>();

--- a/src/normal/stagger/index.ts
+++ b/src/normal/stagger/index.ts
@@ -1,0 +1,1 @@
+export * from './stagger';

--- a/src/normal/stagger/stagger.ts
+++ b/src/normal/stagger/stagger.ts
@@ -4,7 +4,7 @@ import { Normal } from '../types';
 
 type Stagger = number | ((i: number) => number);
 
-type Config<T> = {
+export type Config<T> = {
   length: number;
   stagger: Stagger;
   normal: Normal<T>;


### PR DESCRIPTION
- Adds `group(config)` & tests
- Alters imports to be just the normal and the config for each normal; 
```
    const { duration, progress, subscribe } = group({
      one: tween({
        duration: 250,
        from: 0,
        to: 1,
      }),
      two: tween({
        duration: 500,
        from: 0,
        to: 1,
      }),
      three: tween({
        duration: 1000,
        from: {
          property: 0,
        },
        to: {
          property: 1,
        },
      }),
    });

  /**
   * outputs & emits:
   *
   * {
   *   one: 1,
   *   two: 0.5,
   *   three: {
   *     property: 0.25,
   *   },
   * }
   */
   progress(0.25);
```