### PR TITLE
[WIP] Stream

### DIFF
--- a/src/brule/memory/memory.test.ts
+++ b/src/brule/memory/memory.test.ts
@@ -1,4 +1,4 @@
-import { push, stop, start, pull, Signal, Callbag } from '../callbag';
+import { Callbag, pull, push, Signal, start, stop } from '../callbag';
 import { memory } from './memory';
 
 const createLogSink = () => {

--- a/src/brule/memory/memory.ts
+++ b/src/brule/memory/memory.ts
@@ -1,5 +1,5 @@
+import { Callbag, push, Signal, start, stop } from '../callbag';
 import { I, tap } from '../pipe';
-import { Signal, start, stop, push, Callbag } from '../callbag';
 
 export const memory = <T>(inputSink: Callbag<T>) => {
   let memorized: T | null = null;

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,32 +1,40 @@
 /**
  * const drag = controller();
  * const animate = animator();
- * const stream = stream(
+ * const interpolator = stream(
  *  I(value(clamp(normal)))
  *  .I(sequence.interpolate)
  * );
  *
- * start and return stop methods
- * useEffect(() => stream.start(interpolated => {
- *  Do dom manipulations here. could also plug in an emitter if needed.
- * }), [s]);
+ * useEffect(
+ *  () => interpolator.start(interpolated => {
+ *    DOM manipulations here.
+ *  }),
+ *  [s]
+ * );
  *
- * useEffect(() =>
- *    ['animate'].includes(current) &&
- *    animate.start(stream, {
+ * useEffect(
+ *  () => ['animate'].includes(current) &&
+ *    animate(interpolator, {
  *      duration: sequence.duration,
  *      onAnimationComplete: () => send('animationComplete');
- *    })
- * , [animate, s]);
+ *    }),
+ *  [animate, s]
+ * );
  *
- * useEffect(() =>
- *    ['dragging'].includes(current) &&
- *    drag.start(stream)
- * }, [drag, s]);
+ * useEffect(
+ *  () => ['dragging'].includes(current) &&
+ *    drag(interpolator),
+ *  [drag, s]
+ * );
  *
  * useEffect(() => {
- *  const handleMouseMove = I(getCoordFromEvent)
- *    .I((coord) => drag.next(coord));
+ *  const handleMouseMove = (
+ *    I(getXFromEvent)
+ *    .I(getDelta)
+ *    .I(value(progress([0, DRAG_DISTANCE])))
+ *    .I((normalized) => drag.next(normalized))
+ *  );
  *  const handleMouseUp = () => send('dragComplete');
  *
  *  document.addEvenListener('mouseMove', handleMouseMove);

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,0 +1,44 @@
+/**
+ * const drag = controller();
+ * const animate = animator();
+ * const stream = stream(
+ *  I(value(clamp(normal)))
+ *  .I(sequence.interpolate)
+ * );
+ *
+ * start and return stop methods
+ * useEffect(() => stream.start(interpolated => {
+ *  Do dom manipulations here. could also plug in an emitter if needed.
+ * }), [s]);
+ *
+ * useEffect(() =>
+ *    ['animate'].includes(current) &&
+ *    animate.start(stream, {
+ *      duration: sequence.duration,
+ *      onAnimationComplete: () => send('animationComplete');
+ *    })
+ * , [animate, s]);
+ *
+ * useEffect(() =>
+ *    ['dragging'].includes(current) &&
+ *    drag.start(stream)
+ * }, [drag, s]);
+ *
+ * useEffect(() => {
+ *  const handleMouseMove = I(getCoordFromEvent)
+ *    .I((coord) => drag.next(coord));
+ *  const handleMouseUp = () => send('dragComplete');
+ *
+ *  document.addEvenListener('mouseMove', handleMouseMove);
+ *  document.addEvenListener('mouseUp', handleMouseMove);
+ *  return () => {
+ *    document.removeEvenListener('mouseMove', handleMouseMove);
+ *    document.removeEvenListener('mouseup', handleMouseUp);
+ *  }
+ * }, )
+ *
+ * return (
+ *   <div onMouseDown={e => send('dragStart', e.y)}>
+ * );
+ *
+ */

--- a/src/stream/index.ts
+++ b/src/stream/index.ts
@@ -1,0 +1,1 @@
+export * from './stream';

--- a/src/stream/stream.test.ts
+++ b/src/stream/stream.test.ts
@@ -1,0 +1,33 @@
+import { push } from '../brule';
+import { stream } from './stream';
+
+describe('stream(op)', () => {
+  it('doesnt call the operation until stream is started', () => {
+    const testFn = jest.fn();
+    const op = (v: number) => (testFn(), v);
+    const s = stream(op);
+    s(push(5));
+
+    expect(testFn).toHaveBeenCalledTimes(0);
+  });
+
+  it('pushes values through operation to listener', () => {
+    const listener = jest.fn();
+    const s = stream((v: number) => v * 2);
+    s.start((v) => listener(v));
+
+    s(push(10));
+    expect(listener).toHaveBeenCalledWith(20);
+  });
+
+  it('is stopable', () => {
+    const listener = jest.fn();
+    const s = stream((v: number) => v);
+    const stop = s.start((v) => listener(v));
+    s(push(1));
+    expect(listener).toHaveBeenCalledTimes(1);
+    stop();
+    s(push(2));
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -1,0 +1,31 @@
+import { I, memory, Signal, stop } from '../brule';
+
+interface Stream<A, B> {
+  (signal: Signal<A>): void;
+  start: (fn: (value: B) => void) => VoidFunction;
+}
+
+export const stream = <A, B>(op: (a: A) => B): Stream<A, B> => {
+  let terminate: VoidFunction | null = null;
+  let listener: ((value: B) => void) | null = null;
+
+  const apply = memory((signal: Signal<A>) => {
+    if (signal.isStart) {
+      terminate = () => signal.talkback(stop());
+    }
+    if (signal.isPush) {
+      listener && I(op).I(listener)(signal.value);
+    }
+  }) as Stream<A, B>;
+
+  apply.start = (l: (value: B) => void) => {
+    listener = l;
+    return () => {
+      terminate?.();
+      terminate = null;
+      listener = null;
+    };
+  };
+
+  return apply;
+};


### PR DESCRIPTION
Adds `stream(operation)`.

`stream` returns a start and stoppable memory sink that can only be attached to one source at a time, and upon connection to a new source will send it's most recent input
```
const sink = stream((v: number) => v * 2);
const stop = sink.start(console.log);

sink(push(1)); // log 2
sink(push(2)); // log 4
stop();
sink(push(5)); // nothing logged
```